### PR TITLE
fixes to docstrings

### DIFF
--- a/src/Nuclearnorm.jl
+++ b/src/Nuclearnorm.jl
@@ -5,11 +5,12 @@ export Nuclearnorm
 @doc raw"""
     Nuclearnorm(λ)
 
-Returns the rank
+Returns the nuclear norm
 ```math
-f(x) =  \lambda \times \|matrix(x)\|_*
+f(x) =  \lambda \|X\|_*
 ```
-for a nonnegative parameter ``\lambda`` and a vector ``x``.
+for a nonnegative parameter ``\lambda`` and a vector ``x``, where
+``x = \text{vec}(X)``.
 """
 mutable struct Nuclearnorm{R <: Real, S <: AbstractArray, T, Tr, M <: AbstractArray{T}}
   lambda::R

--- a/src/Rank.jl
+++ b/src/Rank.jl
@@ -7,9 +7,10 @@ export Rank
 
 Returns the rank
 ```math
-f(x) =  \lambda \\cdot rank(matrix(x))
+f(x) =  \lambda \text{rank}(X)
 ```
-for a nonnegative parameter ``\lambda`` and a vector ``x``.
+for a nonnegative parameter ``\lambda`` and a vector ``x``, where
+``x = \text{vec}(X)``.
 """
 mutable struct Rank{R <: Real, S <: AbstractArray, T, Tr, M <: AbstractArray{T}}
   lambda::R

--- a/src/ShiftedProximalOperators.jl
+++ b/src/ShiftedProximalOperators.jl
@@ -131,7 +131,7 @@ prox(ψ::ShiftedProximableFunction, q::V, σ::R) where {R <: Real, V <: Abstract
 
 """
     shifted(h, x)
-    shifted(h, x, Δ, χ)
+    shifted(h, x, Δ, ρ)
 
 Construct a shifted proximable function from a proximable function or from
 another shifted proximable function.
@@ -142,28 +142,24 @@ form `shifted(h, x)` returns a `ShiftedProximableFunction` `ψ` such that `ψ(s)
 when `h` is a `ShiftedProximableFunction` and can be used to shift an
 already-shifted proximable function.
 
-The form `shifted(h, x, Δ, χ)` returns a `ShiftedProximableFunction` `ψ` such
+The form `shifted(h, x, Δ, ρ)` returns a `ShiftedProximableFunction` `ψ` such
 that `ψ(s) == h(x + s) + Ind({‖s‖ ≤ Δ})`, where `Ind(.)` represents the
 indicator of a set, in this case the indicator of a ball of radius `Δ`, in
-which the norm is defined by `χ`.
+which the norm is defined by `ρ`.
 
 ### Arguments
 
 * `h::ProximableFunction` (including a `ShiftedProximableFunction`)
 * `x::AbstractVector`
 * `Δ::Real`
-* `χ::ProximableFunction`.
+* `ρ::ProximableFunction`.
 
-The currently supported combinations are:
-
-* `h::IndBallL0` and `χ::Conjugate{IndBallL1}` (i.e., `χ` is the Inf-norm)
-* `h::NormL0` and `χ::Conjugate{IndBallL1}` (i.e., `χ` is the Inf-norm)
-* `h::NormL1` and `χ::Conjugate{IndBallL1}` (i.e., `χ` is the Inf-norm)
-* `h::NormL1` and `χ::NormL2`.
+Only certain combinations of `h` and `ρ` are supported; those for which the
+analytical form of the proximal operator is known.
 
 If `h` is a shifted proximable function obtained from a previous call to
 `shifted()`, only the form `shifted(h, x)` is supported. If applicable, the
-resulting shifted proximable function is associated with the same `Δ` and `χ`
+resulting shifted proximable function is associated with the same `Δ` and `ρ`
 as `h`.
 
 See the documentation of ProximalOperators.jl for more information.

--- a/src/cappedl1.jl
+++ b/src/cappedl1.jl
@@ -5,11 +5,12 @@ export Cappedl1
 @doc raw"""
     Cappedl1(λ, θ)
 
-Returns the rank
+Returns the capped L1 approximation to the rank function
 ```math
-f(x) =  \lambda \times \min(θ, σ(matrix(x)))
+f(x) =  \lambda \min(θ, σ(X))
 ```
-for a nonnegative parameter ``\lambda``, ``\theta`` and a vector ``x``.
+for nonnegative parameters ``\lambda`` and ``\theta``, and a vector ``x``, where
+``x = \text{vec}(X)``.
 """
 mutable struct Cappedl1{R <: Real, S <: AbstractArray, T, Tr, M <: AbstractArray{T}}
   lambda::R


### PR DESCRIPTION
The symbol χ renders as "x" in the documentation. Changing it to ρ.