### PR TITLE
Shifted documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+docs/build/
+
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,11 @@ authors = ["rjbaraldi <rbaraldi@uw.edu>"]
 version = "0.1.0"
 
 [deps]
-libblastrampoline_jll = "8e850b90-86db-534c-a0d3-1478176c7d93"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OpenBLAS32_jll = "656ef2d0-ae68-5445-9ca0-591084a874a2"
 ProximalOperators = "a725b495-10eb-56fe-b38b-717eba820537"
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
+libblastrampoline_jll = "8e850b90-86db-534c-a0d3-1478176c7d93"
 
 [compat]
 OpenBLAS32_jll = "0.3.9"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,6 +10,10 @@ for use in the algorithms implemented in [RegularizedOptimization.jl](https://gi
 The main differences with the proximal operators implemented in
 [ProximalOperators.jl](https://github.com/JuliaFirstOrder/ProximalOperators.jl)
 are that those implemented here involve a shift of the nonsmooth term and may include an extra indicator function.
+We also implement new proximal operators.
+
+## Proximal operators
+
 The operators from 
 [ProximalOperators.jl](https://github.com/JuliaFirstOrder/ProximalOperators.jl)
 can be written as
@@ -17,8 +21,6 @@ can be written as
 ```math
 \mathrm{prox}_{\nu h}(q) = \arg\min_t \left\{ \tfrac{1}{2}\|t-q\|^2 + \nu h(t) \right\}
 ```
-
-## Proximal operators
 
 We consider a proximal operator from [ProximalOperators.jl](https://github.com/JuliaFirstOrder/ProximalOperators.jl), for example [`ProximalOperators.NormL1`](https://juliafirstorder.github.io/ProximalOperators.jl/stable/functions/#ProximalOperators.NormL1).
 
@@ -29,8 +31,7 @@ h = NormL1(1.0) # proximal operator
 
 This package provides the following shifted proximal operators,
 where `x` and `s` are fixed shifts, `h` is the nonsmooth term with respect
-to which we are computing the proximal operator, `χ(.; ΔB)` is the indicator of
-a ball of radius `Δ` defined by a certain norm.
+to which we are computing the proximal operator.
 
 ## Basic shifted proximal operator
 
@@ -57,6 +58,8 @@ which models
 ```
 
 ## Ball shifted proximal operator
+
+Let `χ(.; ΔB)` be the indicator of a ball of radius `Δ` defined by a certain norm.
 
 ```julia
 χ = NormL2(1.0) # choose the 2-norm for χ

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,1 +1,107 @@
 # ShiftedProximalOperators.jl
+
+## Introduction
+
+ShiftedProximalOperators is a library of proximal operators associated with proper
+lower-semicontinuous functions such as those implemented in
+[ProximalOperators.jl](https://github.com/JuliaFirstOrder/ProximalOperators.jl)
+for use in the algorithms implemented in [RegularizedOptimization.jl](https://github.com/JuliaSmoothOptimizers/RegularizedOptimization.jl).
+
+The main difference between the proximal operators implemented in
+[ProximalOperators.jl](https://github.com/JuliaFirstOrder/ProximalOperators.jl)
+is that those implemented here involve a translation of the nonsmooth term.
+The operators from 
+[ProximalOperators.jl](https://github.com/JuliaFirstOrder/ProximalOperators.jl)
+can be written as
+
+```math
+\mathrm{prox}_{\nu h}(q) = \arg\min_t \left\{ \tfrac{1}{2}\|t-q\|^2 + \nu h(t) \right\}
+```
+
+## Proximal operators
+
+We consider a proximal operator from [ProximalOperators.jl](https://github.com/JuliaFirstOrder/ProximalOperators.jl), for example [`ProximalOperators.NormL1`](https://juliafirstorder.github.io/ProximalOperators.jl/stable/functions/#ProximalOperators.NormL1).
+
+```julia
+using ProximalOperators, ShiftedProximalOperators
+h = NormL1(1.0) # proximal operator
+```
+
+This package provides the following shifted proximal operators,
+where `x` and `s` are fixed shifts, `h` is the nonsmooth term with respect
+to which we are computing the proximal operator, `χ(.; ΔB)` is the indicator of
+a ball of radius `Δ` defined by a certain norm.
+
+## Basic shifted proximal operator
+
+```julia
+ψ = shifted(h, x)
+```
+
+models
+
+```math
+\mathrm{prox}_{\nu h}(q; x) = \arg\min_t \left\{ \tfrac{1}{2}\|t-q\|^2 + \nu h(x + t) \right\}
+```
+
+`ψ` can be shifted again using
+
+```julia
+ψs = shifted(ψ, sj)
+```
+
+which models
+
+```math
+\mathrm{prox}_{\nu h}(q; x, s) = \arg\min_t \left\{ \tfrac{1}{2}\|t-q\|^2 + \nu h(x + s + t) \right\}
+```
+
+## Ball shifted proximal operator
+
+```julia
+χ = NormL2(1.0) # choose the 2-norm for χ
+ψ = shifted(h, x, Δ, χ) # Δ is the radius of the ball ΔB
+```
+
+models
+
+```math
+\mathrm{prox}_{\nu h + \chi}(q; x) = \arg\min_t \left\{ \tfrac{1}{2}\|t-q\|^2 + \nu h(x + t) + \chi (t; \Delta \mathcal{B}) \right\}
+```
+
+`ψ` can be shifted again using
+
+```julia
+ψs = shifted(ψ, sj)
+```
+
+which models
+
+```math
+\mathrm{prox}_{\nu h + \chi}(q; x, s) = \arg\min_t \left\{ \tfrac{1}{2}\|t-q\|^2 + \nu h(x + s + t) + \chi (s + t; \Delta \mathcal{B}) \right\}
+```
+
+## Box shifted proximal operator
+
+```julia
+ψ = shifted(h, x, l, u)
+```
+
+models
+
+```math
+\mathrm{prox}_{\nu h + \chi}(q; x) = \arg\min_t \left\{ \tfrac{1}{2}\|t-q\|^2 + \nu h(x + t) + \chi (t; [\ell, u]) \right\}
+```
+
+where `χ(t; [ℓ, u])` is `0` if `tᵢ ∈ [ℓᵢ, uᵢ]` for all `i ∈ [1, length(t)]` and `+∞` otherwise.
+`ψ` can be shifted again using
+
+```julia
+ψs = shifted(ψ, sj)
+```
+
+which models
+
+```math
+\mathrm{prox}_{\nu h + \chi}(q; x, s) = \arg\min_t \left\{ \tfrac{1}{2}\|t-q\|^2 + \nu h(x + s + t) + \chi (s + t; [\ell, u]) \right\}
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,9 +7,9 @@ lower-semicontinuous functions such as those implemented in
 [ProximalOperators.jl](https://github.com/JuliaFirstOrder/ProximalOperators.jl)
 for use in the algorithms implemented in [RegularizedOptimization.jl](https://github.com/JuliaSmoothOptimizers/RegularizedOptimization.jl).
 
-The main difference between the proximal operators implemented in
+The main differences with the proximal operators implemented in
 [ProximalOperators.jl](https://github.com/JuliaFirstOrder/ProximalOperators.jl)
-is that those implemented here involve a translation of the nonsmooth term.
+are that those implemented here involve a shift of the nonsmooth term and may include an extra indicator function.
 The operators from 
 [ProximalOperators.jl](https://github.com/JuliaFirstOrder/ProximalOperators.jl)
 can be written as

--- a/src/ShiftedProximalOperators.jl
+++ b/src/ShiftedProximalOperators.jl
@@ -139,12 +139,16 @@ prox!
 
 Evaluate the indefinite proximal operator of a separable box shifted regularizer, i.e, return
 a solution y of
-    minimize{yᵢ}  ½ dᵢyᵢ² + gᵢ yᵢ + ψ(yᵢ), i ∈ {1, ..., length(y)}
+
+    minimize{y}  ½ yᵀDy + gᵀy + ψ(y)
+
 where
+
 * ψ is a `ShiftedProximableFunction` representing a model of the sum of a separable function h(x + s) and
   the indicator of a trust region;
 * g is a vector;
-* d is a vector.
+* `D = Diagonal(d)` where d is a vector.
+
 The solution is stored in the input vector `y` an `y` is returned.
 """
 iprox!


### PR DESCRIPTION
Hi, I tried to add some documentation concerning the usage of `shifted`.

I don't think that the documentation I wrote here about the box shifted operator corresponds to the source code. I am missing the `Δ` parameter, and also maybe the selected parameter. However, when looking at the source code of the "Box" files (L1 and L0) it looks like `Δ` is not used (maybe redundant with `l` and `u` ?). Should I consider making a PR to remove this parameter, or am I missing something? 