### PR TITLE
Remove unused delta box operators

### DIFF
--- a/src/shiftedNormL0Box.jl
+++ b/src/shiftedNormL0Box.jl
@@ -15,7 +15,6 @@ mutable struct ShiftedNormL0Box{
   sol::V2
   l::V3
   u::V4
-  Δ::R
   shifted_twice::Bool
   selected::AbstractArray{T}
 
@@ -25,7 +24,6 @@ mutable struct ShiftedNormL0Box{
     sj::AbstractVector{R},
     l,
     u,
-    Δ::R,
     shifted_twice::Bool,
     selected::AbstractArray{T},
   ) where {R <: Real, T <: Integer}
@@ -40,7 +38,6 @@ mutable struct ShiftedNormL0Box{
       sol,
       l,
       u,
-      Δ,
       shifted_twice,
       selected,
     )
@@ -52,9 +49,8 @@ shifted(
   xk::AbstractVector{R},
   l,
   u,
-  Δ::R,
   selected::AbstractArray{T} = 1:length(xk),
-) where {R <: Real, T <: Integer} = ShiftedNormL0Box(h, xk, zero(xk), l, u, Δ, false, selected)
+) where {R <: Real, T <: Integer} = ShiftedNormL0Box(h, xk, zero(xk), l, u, false, selected)
 shifted(
   ψ::ShiftedNormL0Box{R, T, V0, V1, V2, V3, V4},
   sj::AbstractVector{R},
@@ -66,7 +62,7 @@ shifted(
   V2 <: AbstractVector{R},
   V3,
   V4,
-} = ShiftedNormL0Box(ψ.h, ψ.xk, sj, ψ.l, ψ.u, ψ.Δ, true, ψ.selected)
+} = ShiftedNormL0Box(ψ.h, ψ.xk, sj, ψ.l, ψ.u, true, ψ.selected)
 
 function (ψ::ShiftedNormL0Box)(y)
   val = ψ.h((ψ.xk + ψ.sj + y)[ψ.selected])

--- a/src/shiftedNormL1Box.jl
+++ b/src/shiftedNormL1Box.jl
@@ -15,7 +15,6 @@ mutable struct ShiftedNormL1Box{
   sol::V2
   l::V3
   u::V4
-  Δ::R
   shifted_twice::Bool
   selected::AbstractArray{T}
 
@@ -25,7 +24,6 @@ mutable struct ShiftedNormL1Box{
     sj::AbstractVector{R},
     l,
     u,
-    Δ::R,
     shifted_twice::Bool,
     selected::AbstractArray{T},
   ) where {R <: Real, T <: Integer}
@@ -40,7 +38,6 @@ mutable struct ShiftedNormL1Box{
       sol,
       l,
       u,
-      Δ,
       shifted_twice,
       selected,
     )
@@ -52,9 +49,8 @@ shifted(
   xk::AbstractVector{R},
   l,
   u,
-  Δ::R,
   selected::AbstractArray{T} = 1:length(xk),
-) where {R <: Real, T <: Integer} = ShiftedNormL1Box(h, xk, zero(xk), l, u, Δ, false, selected)
+) where {R <: Real, T <: Integer} = ShiftedNormL1Box(h, xk, zero(xk), l, u, false, selected)
 shifted(
   ψ::ShiftedNormL1Box{R, T, V0, V1, V2, V3, V4},
   sj::AbstractVector{R},
@@ -66,7 +62,7 @@ shifted(
   V2 <: AbstractVector{R},
   V3,
   V4,
-} = ShiftedNormL1Box(ψ.h, ψ.xk, sj, ψ.l, ψ.u, ψ.Δ, true, ψ.selected)
+} = ShiftedNormL1Box(ψ.h, ψ.xk, sj, ψ.l, ψ.u, true, ψ.selected)
 
 function (ψ::ShiftedNormL1Box)(y)
   val = ψ.h((ψ.xk + ψ.sj + y)[ψ.selected])

--- a/test/partial_prox.jl
+++ b/test/partial_prox.jl
@@ -12,7 +12,7 @@ for op ∈ (:NormL0, :NormL1, :RootNormLhalf)
     χ = NormLinf(1.0)
 
     # compute the prox wrt all variables
-    ψ = op == :RootNormLhalf ? shifted(h, x, Δ, χ) : shifted(h, x, l, u, Δ)
+    ψ = op == :RootNormLhalf ? shifted(h, x, Δ, χ) : shifted(h, x, l, u)
     if op == :RootNormLhalf
       # redefine l and u temporarily until this operator supports bound constraints
       l .= -Δ
@@ -24,7 +24,7 @@ for op ∈ (:NormL0, :NormL1, :RootNormLhalf)
 
     # compute a partial prox
     selected = 1:2:n
-    ψ = op == :RootNormLhalf ? shifted(h, x, Δ, χ, selected) : shifted(h, x, l, u, Δ, selected)
+    ψ = op == :RootNormLhalf ? shifted(h, x, Δ, χ, selected) : shifted(h, x, l, u, selected)
     ω = shifted(ψ, s)
     σ = 1.0
     z = prox(ω, q, σ)

--- a/test/testsbox.jl
+++ b/test/testsbox.jl
@@ -60,7 +60,7 @@ for (op, shifted_op) ∈ zip((:NormL0, :NormL1), (:ShiftedNormL0Box, :ShiftedNor
       xi = x[i]
       "$shifted_op" == "ShiftedNormL0Box" ? λi = λ[i] : λi = λ
       h = eval(op)(λi)
-      ψ = shifted(h, xi, l, u, 1.0)
+      ψ = shifted(h, xi, l, u)
       ω = shifted(ψ, s)
       ShiftedProximalOperators.prox(ω, qi, σ)
       @test ω.sol == sol[i]


### PR DESCRIPTION
For NormL0Box and NormL1Box.

This will be breaking for box operators because `shifted(h, x, l, u, Δ)` becomes `shifted(h, x, l, u)`, and `set_radius!` will no longer work (it did not really updated the trust region before but will now return an error message indicating that there is no field `Δ`, `set_bounds!` should be used instead). I think that `Δ` was not used in these shifted operators.