### PR TITLE
Iprox for L0Norm and L1Norm

### DIFF
--- a/src/ShiftedProximalOperators.jl
+++ b/src/ShiftedProximalOperators.jl
@@ -147,8 +147,22 @@ where
 * d is a vector.
 
 The solution is stored in the input vector `y` an `y` is returned.
+
+    iprox!(y, ψ, q, σ)
+
+where `σ` is a positive regularization parameter returns `prox!(y, ψ, q, σ)` and an error if `σ ≤ 0`.
 """
 iprox!
+
+function iprox!(
+  y::AbstractVector{R},
+  ψ::ShiftedProximableFunction,
+  q::AbstractVector{R},
+  σ::R,
+) where {R <: Real}
+  @assert σ > zero(R)
+  prox!(y, ψ, q, σ)
+end
 
 """
     prox(ψ, q, σ)
@@ -162,6 +176,7 @@ prox(ψ::ShiftedProximableFunction, q::V, σ::R) where {R <: Real, V <: Abstract
 
 """
     iprox(ψ, q, d)
+    iprox(ψ, q, σ)
 
 See the documentation of `iprox!`.
 In this form, the solution is stored in ψ's internal storage and a reference
@@ -169,6 +184,8 @@ is returned.
 """
 iprox(ψ::ShiftedProximableFunction, q::V, d::AbstractVector{R}) where {R <: Real, V <: AbstractVector{R}} =
   iprox!(ψ.sol, ψ, q, d)
+iprox(ψ::ShiftedProximableFunction, q::V, σ::R) where {R <: Real, V <: AbstractVector{R}} =
+  iprox!(ψ.sol, ψ, q, σ)
 
 """
     prox_zero(q, l, u)

--- a/src/ShiftedProximalOperators.jl
+++ b/src/ShiftedProximalOperators.jl
@@ -18,7 +18,7 @@ function __init__()
 end
 
 export ShiftedProximableFunction
-export prox, prox!, set_radius!, shift!, shifted, set_bounds!
+export prox, prox!, iprox, iprox!, set_radius!, shift!, shifted, set_bounds!
 
 # import methods we override
 import ProximalOperators.prox, ProximalOperators.prox!
@@ -132,6 +132,25 @@ The solution is stored in the input vector `y` an `y` is returned.
 prox!
 
 """
+    iprox!(y, ψ, q, d)
+
+Evaluate the indefinite proximal operator of a separable box shifted regularizer, i.e, return
+a solution y of
+
+    minimize{yᵢ}  ½ dᵢ ‖yᵢ - qᵢ‖₂² + ψ(yᵢ), i ∈ {1, ..., length(q)}
+
+where
+
+* ψ is a `ShiftedProximableFunction` representing a model of the sum of a separable function h(x + s) and
+  the indicator of a trust region;
+* q is the vector where the shifted proximal operator should be evaluated;
+* d is a vector.
+
+The solution is stored in the input vector `y` an `y` is returned.
+"""
+iprox!
+
+"""
     prox(ψ, q, σ)
 
 See the documentation of `prox!`.
@@ -140,6 +159,16 @@ is returned.
 """
 prox(ψ::ShiftedProximableFunction, q::V, σ::R) where {R <: Real, V <: AbstractVector{R}} =
   prox!(ψ.sol, ψ, q, σ)
+
+"""
+    iprox(ψ, q, d)
+
+See the documentation of `iprox!`.
+In this form, the solution is stored in ψ's internal storage and a reference
+is returned.
+"""
+iprox(ψ::ShiftedProximableFunction, q::V, d::AbstractVector{R}) where {R <: Real, V <: AbstractVector{R}} =
+  iprox!(ψ.sol, ψ, q, d)
 
 """
     prox_zero(q, l, u)
@@ -153,6 +182,19 @@ separable nonsmooth term along a variable that is not part of those to which
 the nonsmooth term is applied.
 """
 @inline prox_zero(q::R, l::R, u::R) where {R <: Real} = min(max(q, l), u)
+
+"""
+    negative_prox_zero(q, l, u)
+
+Return the solution of
+
+    min ½ σ⁻¹ (y - q)² subject to l ≤ y ≤ u
+
+for any σ < 0. This problem occurs when computing the iprox with respect to a
+separable nonsmooth term along a variable that is not part of those to which
+the nonsmooth term is applied.
+"""
+negative_prox_zero(q::R, l::R, u::R) where {R <: Real} = (abs(u - q) < abs(l - q)) ? l : u
 
 """
     shifted(h, x)

--- a/src/shiftedNormL0Box.jl
+++ b/src/shiftedNormL0Box.jl
@@ -155,6 +155,34 @@ function prox!(
   return y
 end
 
+function solve_ith_subproblem_iproxL0_neg(
+  li::R,
+  ui::R,
+  xi::R,
+  si::R,
+  xs::R, # xi + si
+  sq::R, # xi + qi
+  xsq::R, # xi + si + qi
+  ci::R,
+) where {R <: Real}
+  # yi = arg max (yi - qi)^2 + ci||xi + si + yi||₀ - χ(si + yi | [li, ui])
+  # where ci < 0 (ci = 2λ / di)
+  # possible maxima locations:
+  # yi = li - si
+  # yi = ui - si
+  # yi = -xi - si, if: li + xi ≤ 0 ≤ ui + xi, leads to h(xi + si + yi) = 0
+  val_left = (li - sq)^2 + (xi == -li ? 0 : ci) # left: yi = li - si
+  val_right = (ui - sq)^2 + (xi == -ui ? 0 : ci) # right: yi = ui - si
+  yi = val_left > val_right ? (li - si) : (ui - si)
+  val_max = max(val_left, val_right)
+  if li ≤ -xi ≤ ui  # <=> li + xi ≤ 0 ≤ ui + xi
+    # compute (xi + si + qi)^2 with y = -xi - si so that h(xi + si + y) = 0
+    val_0 = xsq^2
+    val_0 > val_max && (yi = -xs)
+  end
+  return yi
+end
+
 function iprox!(
   y::AbstractVector{R},
   ψ::ShiftedNormL0Box{R, T, V0, V1, V2, V3, V4},
@@ -186,39 +214,77 @@ function iprox!(
       xi = ψ.xk[i]
       xs = xi + si
       xsq = xs + qi
-
       if di > eps(R)
         # yi = arg min (yi - qi)^2 + 2λ||xi + si + yi||₀ / di + χ(si + yi | [li, ui])
         y[i] = solve_ith_subproblem_proxL0(li, ui, xi, si, qi, xs, sq, xsq, ci)
       elseif di < -eps(R)
         # yi = arg max (yi - qi)^2 + 2λ||xi + si + yi||₀ / di - χ(si + yi | [li, ui])
-        # possible maxima locations:
-        # yi = li - si
-        # yi = ui - si
-        # yi = -xi - si, if: li + xi ≤ 0 ≤ ui + xi, leads to h(xi + si + yi) = 0
-        val_left = (li - sq)^2 + (xi == -li ? 0 : ci) # left: yi = li - si
-        val_right = (ui - sq)^2 + (xi == -ui ? 0 : ci) # right: yi = ui - si
-        y[i] = val_left > val_right ? (li - si) : (ui - si)
-        val_max = max(val_left, val_right)
-        if li ≤ -xi ≤ ui  # <=> li + xi ≤ 0 ≤ ui + xi
-          # compute (xi + si + qi)^2 with y = -xi - si so that h(xi + si + y) = 0
-          val_0 = xsq^2
-          val_0 > val_max && (y[i] = -xs)
-        end
+        y[i] = solve_ith_subproblem_iproxL0_neg(li, ui, xi, si, xs, sq, xsq, ci) 
       else # abs(di) < eps(R) (consider di = 0 in this case)
         # yi = arg min h(xi + si + yi) + χ(si + yi | [li, ui])
         y[i] = (li ≤ -xi ≤ ui) ? -xs : zero(R)
         # maybe set something else than 0
       end
     else # min ½ di⁻¹ (y - qi)² subject to li - si ≤ y ≤ ui - si
-      if di > eps(R)
-        y[i] = prox_zero(qi, li - si, ui - si)
-      elseif di < -eps(R)
+      y[i] = iprox_zero(qi, li, ui, si, di)
+    end
+  end
+  return y
+end
+
+function iprox!(
+  y::AbstractVector{R},
+  ψ::ShiftedNormL0Box{R, T, V0, V1, V2, V3, V4},
+  q::AbstractVector{R},
+  d::R,
+) where {
+  R <: Real,
+  T <: Integer,
+  V0 <: AbstractVector{R},
+  V1 <: AbstractVector{R},
+  V2 <: AbstractVector{R},
+  V3,
+  V4,
+}
+
+  if d > eps(R)
+    prox!(y, ψ, q, d)
+  elseif d < - eps(R)
+    c = 2 * ψ.λ / d
+    for i ∈ eachindex(q)
+      li = isa(ψ.l, Real) ? ψ.l : ψ.l[i]
+      ui = isa(ψ.u, Real) ? ψ.u : ψ.u[i]
+      qi = q[i]
+      si = ψ.sj[i]
+      sq = si + qi
+      # yi = arg min d * (yi - qi)^2 /2 + h(xi + si + yi) + χ(si + yi | [li, ui])
+      if i ∈ ψ.selected
+        xi = ψ.xk[i]
+        xs = xi + si
+        xsq = xs + qi
+        # yi = arg max (yi - qi)^2 + 2λ||xi + si + yi||₀ / d - χ(si + yi | [li, ui])
+        y[i] = solve_ith_subproblem_iproxL0_neg(li, ui, xi, si, xs, sq, xsq, c) 
+      else # min ½ d⁻¹ (y - qi)² subject to li - si ≤ y ≤ ui - si
         y[i] = negative_prox_zero(qi, li - si, ui - si)
-      else
+      end
+    end
+  else # abs(di) < eps(R) (consider di = 0 in this case)
+    for i ∈ eachindex(q)
+      li = isa(ψ.l, Real) ? ψ.l : ψ.l[i]
+      ui = isa(ψ.u, Real) ? ψ.u : ψ.u[i]
+      si = ψ.sj[i]
+      # yi = arg min di * (yi - qi)^2 /2 + h(xi + si + yi) + χ(si + yi | [li, ui])
+      if i ∈ ψ.selected
+        xi = ψ.xk[i]
+        xs = xi + si
+        # yi = arg min h(xi + si + yi) + χ(si + yi | [li, ui])
+        y[i] = (li ≤ -xi ≤ ui) ? -xs : zero(R)
+        # maybe set something else than 0
+      else # min 0 subject to li - si ≤ y ≤ ui - si
         y[i] = zero(R)
       end
     end
   end
+
   return y
 end

--- a/src/shiftedNormL1Box.jl
+++ b/src/shiftedNormL1Box.jl
@@ -82,6 +82,19 @@ fun_expr(ψ::ShiftedNormL1Box) = "t ↦ ‖xk + sj + t‖₁ + χ({sj + t .∈ [
 fun_params(ψ::ShiftedNormL1Box) =
   "xk = $(ψ.xk)\n" * " "^14 * "sj = $(ψ.sj)\n" * " "^14 * "l = $(ψ.l)\n" * " "^14 * "u = $(ψ.u)"
 
+# solve i-th subproblem of the proximal operator
+function solve_ith_subproblem_proxL1(li::R, ui::R, si::R, qi::R, xs::R, xsq::R, ci::R) where {R <: Real}
+  yi = if xsq ≤ -ci
+    qi + ci
+  elseif xsq ≥ ci
+    qi - ci
+  else
+    -xs
+  end
+  yi = min(max(yi, li - si), ui - si)
+  return yi
+end
+
 function prox!(
   y::AbstractVector{R},
   ψ::ShiftedNormL1Box{R, T, V0, V1, V2, V3, V4},
@@ -104,27 +117,35 @@ function prox!(
 
     qi = q[i]
     si = ψ.sj[i]
-    sq = si + qi
 
     if i ∈ ψ.selected
       xi = ψ.xk[i]
       xs = xi + si
       xsq = xs + qi
-
-      y[i] = if xsq ≤ -σλ
-        qi + σλ
-      elseif xsq ≥ σλ
-        qi - σλ
-      else
-        -xs
-      end
-      y[i] = min(max(y[i], li - si), ui - si)
-
+      y[i] = solve_ith_subproblem_proxL1(li, ui, si, qi, xs, xsq, σλ)
     else # min ½ σ⁻¹ (y - qi)² subject to li-si ≤ y ≤ ui-si
       y[i] = prox_zero(qi, li - si, ui - si)
     end
   end
   return y
+end
+
+function solve_ith_subproblem_iproxL1_neg(li::R, ui::R, xi::R, si::R, sq::R, xs::R, xsq::R, ci::R) where {R <: Real}
+  # yi = arg max (yi - qi)^2 + ci|xi + si + yi| - χ(si + yi | [li, ui])
+  # where ci < 0 (ci = 2λ / di)
+  # possible maxima locations:
+  # yi = li - si
+  # yi = ui - si
+  # yi = -xi - si, if: li + xi ≤ 0 ≤ ui + xi, leads to h(xi + si + yi) = 0
+  val_left = (li - sq)^2 + ci * abs(xi + li) # left: yi = li - si
+  val_right = (ui - sq)^2 + ci * abs(xi + ui) # right: yi = ui - si
+  yi = val_left > val_right ? (li - si) : (ui - si)
+  val_max = max(val_left, val_right)
+  if (li ≤ -xi ≤ ui)
+    val_0 = xsq^2
+    (val_0 > val_max) && (yi = -xs)
+  end
+  return yi
 end
 
 function iprox!(
@@ -161,29 +182,11 @@ function iprox!(
 
       if di > eps(R)
         ci = λ / di
-        y[i] = if xsq ≤ -ci
-          qi + ci
-        elseif xsq ≥ ci
-          qi - ci
-        else
-          -xs
-        end
-        y[i] = min(max(y[i], li - si), ui - si)
+        y[i] = solve_ith_subproblem_proxL1(li, ui, si, qi, xs, xsq, ci)
       elseif di < -eps(R)
         # yi = arg max (yi - qi)^2 + 2λ|xi + si + yi| / di - χ(si + yi | [li, ui])
-        # possible maxima locations:
-        # yi = li - si
-        # yi = ui - si
-        # yi = -xi - si, if: li + xi ≤ 0 ≤ ui + xi, leads to h(xi + si + yi) = 0
         ci = λ2 / di
-        val_left = (li - sq)^2 + ci * abs(xi + li) # left: yi = li - si
-        val_right = (ui - sq)^2 + ci * abs(xi + ui) # right: yi = ui - si
-        y[i] = val_left > val_right ? (li - si) : (ui - si)
-        val_max = max(val_left, val_right)
-        if (li ≤ -xi ≤ ui)
-          val_0 = xsq^2
-          (val_0 > val_max) && (y[i] = -xs)
-        end
+        y[i] = solve_ith_subproblem_iproxL1_neg(li, ui, xi, si, sq, xs, xsq, ci)
       else # abs(di) < eps(R) , (we consider di = 0)
         y[i] = prox_zero(-xs, li - si, ui - si)
       end 
@@ -198,5 +201,58 @@ function iprox!(
       end
     end
   end
+  return y
+end
+
+function iprox!(
+  y::AbstractVector{R},
+  ψ::ShiftedNormL1Box{R, T, V0, V1, V2, V3, V4},
+  q::AbstractVector{R},
+  d::R,
+) where {
+  R <: Real,
+  T <: Integer,
+  V0 <: AbstractVector{R},
+  V1 <: AbstractVector{R},
+  V2 <: AbstractVector{R},
+  V3,
+  V4,
+}
+
+  if d > eps(R)
+    prox!(y, ψ, q, d)
+  elseif d < -eps(R)
+    c = 2 * ψ.λ / d
+    for i ∈ eachindex(y)
+      li = isa(ψ.l, Real) ? ψ.l : ψ.l[i]
+      ui = isa(ψ.u, Real) ? ψ.u : ψ.u[i]
+      qi = q[i]
+      si = ψ.sj[i]
+      sq = si + qi
+      if i ∈ ψ.selected
+        # yi = arg max (yi - qi)^2 + 2λ|xi + si + yi| / d - χ(si + yi | [li, ui])
+        xi = ψ.xk[i]
+        xs = xi + si
+        xsq = xs + qi
+        y[i] = solve_ith_subproblem_iproxL1_neg(li, ui, xi, si, sq, xs, xsq, c)
+      else # min ½ di (y - qi)² subject to li-si ≤ y ≤ ui-si
+        y[i] = negative_prox_zero(qi, li - si, ui - si)
+      end
+    end
+  else # abs(di) < eps(R) (consider di = 0 in this case)
+    for i ∈ eachindex(y)
+      li = isa(ψ.l, Real) ? ψ.l : ψ.l[i]
+      ui = isa(ψ.u, Real) ? ψ.u : ψ.u[i]
+      si = ψ.sj[i]
+      if i ∈ ψ.selected
+        xi = ψ.xk[i]
+        xs = xi + si
+        y[i] = prox_zero(-xs, li - si, ui - si)
+      else # min 0 subject to li-si ≤ y ≤ ui-si
+        y[i] = zero(R)
+      end
+    end
+  end
+
   return y
 end

--- a/test/partial_prox.jl
+++ b/test/partial_prox.jl
@@ -38,7 +38,7 @@ for op ∈ (:NormL0, :NormL1, :RootNormLhalf)
       end
     end
 
-    if op == :NormL0
+    if op == :NormL0 || op == :NormL1
       d = ones(n) # d = e
       y = iprox(ω, q, d)
       ω = shifted(ψ, s)

--- a/test/partial_prox.jl
+++ b/test/partial_prox.jl
@@ -37,5 +37,49 @@ for op ∈ (:NormL0, :NormL1, :RootNormLhalf)
         @test z[i] == p[i]
       end
     end
+
+    if op == :NormL0
+      d = ones(n) # d = e
+      y = iprox(ω, q, d)
+      ω = shifted(ψ, s)
+      σ = 1.0
+      z = iprox(ω, q, d)
+      p = min.(max.(q, l - s), u - s)
+      for i = 1:n
+        if i ∈ selected
+          @test z[i] == y[i]
+        else
+          @test z[i] == p[i]
+        end
+      end
+
+      d = -ones(n) # d = -e
+      y = iprox(ω, q, d)
+      ω = shifted(ψ, s)
+      z = iprox(ω, q, d)
+      p = zeros(n)
+      for i=1:n
+        p[i] = (abs(u[i] - s[i] - q[i]) < abs(l[i] - s[i] - q[i])) ? (l[i] - s[i]) : (u[i] - s[i])
+      end
+      for i = 1:n
+        if i ∈ selected
+          @test z[i] == y[i]
+        else
+          @test z[i] == p[i]
+        end
+      end
+
+      d = zeros(n) # d = 0*e
+      y = iprox(ω, q, d)
+      ω = shifted(ψ, s)
+      z = iprox(ω, q, d)
+      for i = 1:n
+        if i ∈ selected
+          @test z[i] == y[i]
+        else
+          @test z[i] == 0.0
+        end
+      end
+    end
   end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -389,7 +389,13 @@ for (op, tr, shifted_op) ∈ zip(
         0.010000000000000,
       ]
     end
+    
     s = ShiftedProximalOperators.prox(ψ, q, ν)
+    @test all(s .≈ s_correct)
+    @test χ(s) ≤ Δ
+
+    # test iprox redirection to prox if ν > 0
+    s = ShiftedProximalOperators.iprox(ψ, q, ν)
     @test all(s .≈ s_correct)
     @test χ(s) ≤ Δ
 

--- a/test/testsbox.jl
+++ b/test/testsbox.jl
@@ -113,6 +113,8 @@ for (op, shifted_op) ∈ zip((:NormL0, :NormL1), (:ShiftedNormL0Box, :ShiftedNor
       ω = shifted(ψ, s)
       ShiftedProximalOperators.prox(ω, qi, σ)
       @test ω.sol == sol[i]
+      ShiftedProximalOperators.iprox(ω, qi, σ)
+      @test ω.sol == sol[i]
     end
     # iprox, d = 1.0
     for i = 1:9

--- a/test/testsbox.jl
+++ b/test/testsbox.jl
@@ -113,8 +113,6 @@ for (op, shifted_op) ∈ zip((:NormL0, :NormL1), (:ShiftedNormL0Box, :ShiftedNor
       ω = shifted(ψ, s)
       ShiftedProximalOperators.prox(ω, qi, σ)
       @test ω.sol == sol[i]
-      ShiftedProximalOperators.iprox(ω, qi, σ)
-      @test ω.sol == sol[i]
     end
     # iprox, d = 1.0
     for i = 1:9
@@ -125,6 +123,8 @@ for (op, shifted_op) ∈ zip((:NormL0, :NormL1), (:ShiftedNormL0Box, :ShiftedNor
       ψ = shifted(h, xi, l, u)
       ω = shifted(ψ, s)
       ShiftedProximalOperators.iprox(ω, qi, d)
+      @test ω.sol == sol[i]
+      ShiftedProximalOperators.iprox(ω, qi, d[1])
       @test ω.sol == sol[i]
     end
     # iprox, d = -1.0
@@ -138,6 +138,8 @@ for (op, shifted_op) ∈ zip((:NormL0, :NormL1), (:ShiftedNormL0Box, :ShiftedNor
       ω = shifted(ψ, s)
       ShiftedProximalOperators.iprox(ω, qi2, d2)
       @test ω.sol == sol2[i]
+      ShiftedProximalOperators.iprox(ω, qi2, d2[1])
+      @test ω.sol == sol2[i]
     end
     # iprox, d = 0.0 
     for i=1:3
@@ -149,6 +151,8 @@ for (op, shifted_op) ∈ zip((:NormL0, :NormL1), (:ShiftedNormL0Box, :ShiftedNor
       ψ = shifted(h, xi3, l, u)
       ω = shifted(ψ, s)
       ShiftedProximalOperators.iprox(ω, qi3, d3)
+      @test ω.sol == sol3[i]
+      ShiftedProximalOperators.iprox(ω, qi3, d3[1])
       @test ω.sol == sol3[i]
     end
   end


### PR DESCRIPTION
We call `iprox!(y, ψ, q, d)` as we would call  `prox!(y, ψ, q, σ)` but here `d` is a vector.
When `d[i] < 0`, I converted the ith-subproblem to a maximization problem to reduce the number of computations.
For the L0 Norm, I created the function `solve_ith_subproblem_proxL0` to avoid duplicating too much code, since the i-th subproblem of `iprox` and `prox` are very similar if `d[i] > 0`.

https://github.com/JuliaSmoothOptimizers/ShiftedProximalOperators.jl/pull/99 should probably be merged first.

