### PR TITLE
Remove allocations sum in operator evaluation

### DIFF
--- a/src/ShiftedProximalOperators.jl
+++ b/src/ShiftedProximalOperators.jl
@@ -51,7 +51,10 @@ include("shiftedRank.jl")
 include("shiftedCappedl1.jl")
 include("shiftedNuclearnorm.jl")
 
-(ψ::ShiftedProximableFunction)(y) = ψ.h(ψ.xk + ψ.sj + y)
+function (ψ::ShiftedProximableFunction)(y)
+  @. ψ.xsy = ψ.xk + ψ.sj + y
+  return ψ.h(ψ.xsy)
+end
 
 """
     shift!(ψ, x)

--- a/src/shiftedCappedl1.jl
+++ b/src/shiftedCappedl1.jl
@@ -15,6 +15,7 @@ mutable struct ShiftedCappedl1{
   sj::V1  # current shift
   sol::V2   # internal storage
   shifted_twice::Bool
+  xsy::V2
   function ShiftedCappedl1(
     h::Cappedl1{R, S, T, Tr, M},
     xk::AbstractVector{R},
@@ -22,7 +23,8 @@ mutable struct ShiftedCappedl1{
     shifted_twice::Bool,
   ) where {R <: Real, S <: AbstractArray, T, Tr, M <: AbstractArray{T}}
     sol = similar(xk)
-    new{R, S, T, Tr, M, typeof(xk), typeof(sj), typeof(sol)}(h, xk, sj, sol, shifted_twice)
+    xsy = similar(xk)
+    new{R, S, T, Tr, M, typeof(xk), typeof(sj), typeof(sol)}(h, xk, sj, sol, shifted_twice, xsy)
   end
 end
 

--- a/src/shiftedGroupNormL2.jl
+++ b/src/shiftedGroupNormL2.jl
@@ -13,6 +13,7 @@ mutable struct ShiftedGroupNormL2{
   sj::V1
   sol::V2
   shifted_twice::Bool
+  xsy::V2
 
   function ShiftedGroupNormL2(
     h::GroupNormL2{R, RR, I},
@@ -21,7 +22,8 @@ mutable struct ShiftedGroupNormL2{
     shifted_twice::Bool,
   ) where {R <: Real, RR <: AbstractVector{R}, I}
     sol = similar(sj)
-    new{R, RR, I, typeof(xk), typeof(sj), typeof(sol)}(h, xk, sj, sol, shifted_twice)
+    xsy = similar(sj)
+    new{R, RR, I, typeof(xk), typeof(sj), typeof(sol)}(h, xk, sj, sol, shifted_twice, xsy)
   end
 end
 

--- a/src/shiftedIndBallL0.jl
+++ b/src/shiftedIndBallL0.jl
@@ -13,6 +13,7 @@ mutable struct ShiftedIndBallL0{
   sol::V2
   p::Vector{Int}
   shifted_twice::Bool
+  xsy::V2
 
   function ShiftedIndBallL0(
     h::IndBallL0{I},
@@ -21,6 +22,7 @@ mutable struct ShiftedIndBallL0{
     shifted_twice::Bool,
   ) where {I <: Integer, R <: Real}
     sol = similar(sj)
+    xsy = similar(sj)
     new{I, R, typeof(xk), typeof(sj), typeof(sol)}(
       h,
       xk,
@@ -28,6 +30,7 @@ mutable struct ShiftedIndBallL0{
       sol,
       Vector{Int}(undef, length(sj)),
       shifted_twice,
+      xsy,
     )
   end
 end

--- a/src/shiftedNormL0.jl
+++ b/src/shiftedNormL0.jl
@@ -11,6 +11,7 @@ mutable struct ShiftedNormL0{
   sj::V1  # current shift
   sol::V2   # internal storage
   shifted_twice::Bool
+  xsy::V2
   function ShiftedNormL0(
     h::NormL0{R},
     xk::AbstractVector{R},
@@ -18,7 +19,8 @@ mutable struct ShiftedNormL0{
     shifted_twice::Bool,
   ) where {R <: Real}
     sol = similar(xk)
-    new{R, typeof(xk), typeof(sj), typeof(sol)}(h, xk, sj, sol, shifted_twice)
+    xsy = similar(xk)
+    new{R, typeof(xk), typeof(sj), typeof(sol)}(h, xk, sj, sol, shifted_twice, xsy)
   end
 end
 

--- a/src/shiftedNormL1.jl
+++ b/src/shiftedNormL1.jl
@@ -11,6 +11,7 @@ mutable struct ShiftedNormL1{
   sj::V1
   sol::V2
   shifted_twice::Bool
+  xsy::V2
 
   function ShiftedNormL1(
     h::NormL1{R},
@@ -19,7 +20,8 @@ mutable struct ShiftedNormL1{
     shifted_twice::Bool,
   ) where {R <: Real}
     sol = similar(xk)
-    new{R, typeof(xk), typeof(sj), typeof(sol)}(h, xk, sj, sol, shifted_twice)
+    xsy = similar(xk)
+    new{R, typeof(xk), typeof(sj), typeof(sol)}(h, xk, sj, sol, shifted_twice, xsy)
   end
 end
 

--- a/src/shiftedNormL1B2.jl
+++ b/src/shiftedNormL1B2.jl
@@ -13,6 +13,7 @@ mutable struct ShiftedNormL1B2{
   Δ::R
   χ::NormL2{R}
   shifted_twice::Bool
+  xsy::V2
 
   function ShiftedNormL1B2(
     h::NormL1{R},
@@ -23,7 +24,8 @@ mutable struct ShiftedNormL1B2{
     shifted_twice::Bool,
   ) where {R <: Real}
     sol = similar(sj)
-    new{R, typeof(xk), typeof(sj), typeof(sol)}(h, xk, sj, sol, Δ, χ, shifted_twice)
+    xsy = similar(sj)
+    new{R, typeof(xk), typeof(sj), typeof(sol)}(h, xk, sj, sol, Δ, χ, shifted_twice, xsy)
   end
 end
 

--- a/src/shiftedNuclearnorm.jl
+++ b/src/shiftedNuclearnorm.jl
@@ -15,6 +15,7 @@ mutable struct ShiftedNuclearnorm{
   sj::V1  # current shift
   sol::V2   # internal storage
   shifted_twice::Bool
+  xsy::V2
   function ShiftedNuclearnorm(
     h::Nuclearnorm{R, S, T, Tr, M},
     xk::AbstractVector{R},
@@ -22,7 +23,8 @@ mutable struct ShiftedNuclearnorm{
     shifted_twice::Bool,
   ) where {R <: Real, S <: AbstractArray, T, Tr, M <: AbstractArray{T}}
     sol = similar(xk)
-    new{R, S, T, Tr, M, typeof(xk), typeof(sj), typeof(sol)}(h, xk, sj, sol, shifted_twice)
+    xsy = similar(xk)
+    new{R, S, T, Tr, M, typeof(xk), typeof(sj), typeof(sol)}(h, xk, sj, sol, shifted_twice, xsy)
   end
 end
 

--- a/src/shiftedRank.jl
+++ b/src/shiftedRank.jl
@@ -15,6 +15,7 @@ mutable struct ShiftedRank{
   sj::V1  # current shift
   sol::V2   # internal storage
   shifted_twice::Bool
+  xsy::V2
   function ShiftedRank(
     h::Rank{R, S, T, Tr, M},
     xk::AbstractVector{R},
@@ -22,7 +23,8 @@ mutable struct ShiftedRank{
     shifted_twice::Bool,
   ) where {R <: Real, S <: AbstractArray, T, Tr, M <: AbstractArray{T}}
     sol = similar(xk)
-    new{R, S, T, Tr, M, typeof(xk), typeof(sj), typeof(sol)}(h, xk, sj, sol, shifted_twice)
+    xsy = similar(xk)
+    new{R, S, T, Tr, M, typeof(xk), typeof(sj), typeof(sol)}(h, xk, sj, sol, shifted_twice, xsy)
   end
 end
 

--- a/src/shiftedRootNormLhalf.jl
+++ b/src/shiftedRootNormLhalf.jl
@@ -12,6 +12,7 @@ mutable struct ShiftedRootNormLhalf{
   sj::V1
   sol::V2
   shifted_twice::Bool
+  xsy::V2
 
   function ShiftedRootNormLhalf(
     h::RootNormLhalf{R},
@@ -20,7 +21,8 @@ mutable struct ShiftedRootNormLhalf{
     shifted_twice::Bool,
   ) where {R <: Real}
     sol = similar(xk)
-    new{R, typeof(xk), typeof(sj), typeof(sol)}(h, xk, sj, sol, shifted_twice)
+    xsy = similar(xk)
+    new{R, typeof(xk), typeof(sj), typeof(sol)}(h, xk, sj, sol, shifted_twice, xsy)
   end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -519,7 +519,7 @@ for (op, tr, shifted_op) ∈ zip((:NormL2,), (:NormLinf,), (:ShiftedGroupNormL2B
     @test φ(zeros(n)) == h(y + s)
     t = rand(n)
     t .*= ψ.Δ / ψ.χ(t) / 2
-    @test φ(t) == h(y + s + t)  # y inside the trust region
+    @test φ(t) ≈ h(y + s + t)  # y inside the trust region
     @test φ(3 * t) == Inf       # y outside the trust region
 
     # test different types
@@ -618,7 +618,7 @@ for (op, tr, shifted_op) ∈ zip((:GroupNormL2,), (:NormLinf,), (:ShiftedGroupNo
     @test φ(zeros(n)) == h(y + s)
     t = rand(n)
     t .*= ψ.Δ / ψ.χ(t) / 2
-    @test φ(t) == h(y + s + t)  # y inside the trust region
+    @test φ(t) ≈ h(y + s + t) # y inside the trust region
     @test φ(3 * t) == Inf       # y outside the trust region
 
     # test different types

--- a/test/test_allocs.jl
+++ b/test/test_allocs.jl
@@ -1,10 +1,34 @@
-for op ∈ (:NormL0, :NormL1, :RootNormLhalf)
-  h = eval(op)(1.0)
-  n = 1000
-  xk = rand(n)
-  ψ = shifted(h, xk, -3.0, 4.0, rand(1:n, Int(n / 2)))
-  y = rand(n)
-  val = ψ(y)
-  allocs = @allocated ψ(y)
-  @test allocs == 0
+@testset "allocs" begin
+  for op ∈ (:NormL0, :NormL1, :RootNormLhalf)
+    h = eval(op)(1.0)
+    n = 1000
+    xk = rand(n)
+    ψ = shifted(h, xk)
+    y = rand(n)
+    val = ψ(y)
+    allocs = @allocated ψ(y)
+    @test allocs == 16
+
+    ψ = shifted(h, xk, -3.0, 4.0, rand(1:n, Int(n / 2)))
+    val = ψ(y)
+    allocs = @allocated ψ(y)
+    @test allocs == 0
+  end
+
+  for op ∈ (:IndBallL0,)
+    h = eval(op)(1)
+    n = 1000
+    xk = rand(n)
+    ψ = shifted(h, xk)
+    y = rand(n)
+    val = ψ(y)
+    allocs = @allocated ψ(y)
+    @test allocs == 16
+
+    χ = NormLinf(1.0)
+    ψ = shifted(h, xk, 0.5, χ)
+    val = ψ(y)
+    allocs = @allocated ψ(y)
+    @test allocs == 16
+  end
 end


### PR DESCRIPTION
Add the `xsy` field for all operators. I did not check allocations on the operators specific to this package because some might need some changes (in another PR) to get (almost, see below) zero allocations.