### PR TITLE
Shifted Composite L2 Norm

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,9 @@ version = "0.2.0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OpenBLAS32_jll = "656ef2d0-ae68-5445-9ca0-591084a874a2"
 ProximalOperators = "a725b495-10eb-56fe-b38b-717eba820537"
+QRMumps = "422b30a1-cc69-4d85-abe7-cc07b540c444"
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 libblastrampoline_jll = "8e850b90-86db-534c-a0d3-1478176c7d93"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ ProximalOperators = "a725b495-10eb-56fe-b38b-717eba820537"
 QRMumps = "422b30a1-cc69-4d85-abe7-cc07b540c444"
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+SparseMatricesCOO = "fa32481b-f100-4b48-8dc8-c62f61b13870"
 libblastrampoline_jll = "8e850b90-86db-534c-a0d3-1478176c7d93"
 
 [compat]

--- a/src/ShiftedProximalOperators.jl
+++ b/src/ShiftedProximalOperators.jl
@@ -1,6 +1,8 @@
 module ShiftedProximalOperators
 
 using LinearAlgebra
+using SparseArrays
+using QRMumps
 
 using libblastrampoline_jll
 using OpenBLAS32_jll
@@ -25,16 +27,22 @@ import ProximalOperators.prox, ProximalOperators.prox!
 
 "Abstract type for shifted proximable functions."
 abstract type ShiftedProximableFunction end
+abstract type CompositeProximableFunction end
+
+abstract type AbstractCompositeNorm <: CompositeProximableFunction end
+abstract type ShiftedCompositeProximableFunction <: ShiftedProximableFunction end
 
 include("utils.jl")
 include("psvd.jl")
 
+include("compositeNormL2.jl")
 include("rootNormLhalf.jl")
 include("groupNormL2.jl")
 include("Rank.jl")
 include("cappedl1.jl")
 include("Nuclearnorm.jl")
 
+include("shiftedCompositeNormL2.jl")
 include("shiftedNormL0.jl")
 include("shiftedNormL0Box.jl")
 include("shiftedRootNormLhalf.jl")
@@ -56,6 +64,16 @@ function (ψ::ShiftedProximableFunction)(y)
   return ψ.h(ψ.xsy)
 end
 
+function (ψ::ShiftedCompositeProximableFunction)(y)
+  return ψ.h(ψ.b + ψ.A * y)
+end
+
+function (ψ::CompositeProximableFunction)(y)
+  z = similar(ψ.b)
+  ψ.c!(z, y)
+  ψ.h(z)
+end
+
 """
     shift!(ψ, x)
 
@@ -67,6 +85,12 @@ function shift!(ψ::ShiftedProximableFunction, shift::AbstractVector{R}) where {
   else
     ψ.xk .= shift
   end
+  return ψ
+end
+
+function shift!(ψ::ShiftedCompositeProximableFunction, shift::AbstractVector{R}) where {R <: Real}
+  ψ.c!(ψ.b,shift)
+  ψ.J!(ψ.A,shift)
   return ψ
 end
 

--- a/src/ShiftedProximalOperators.jl
+++ b/src/ShiftedProximalOperators.jl
@@ -3,6 +3,7 @@ module ShiftedProximalOperators
 using LinearAlgebra
 using SparseArrays
 using QRMumps
+using SparseMatricesCOO
 
 using libblastrampoline_jll
 using OpenBLAS32_jll

--- a/src/compositeNormL2.jl
+++ b/src/compositeNormL2.jl
@@ -1,0 +1,51 @@
+# Composition of the L2 norm with a function
+export CompositeNormL2
+
+@doc raw"""
+    CompositeNormL2(λ, c!, J!, A, b)
+
+Returns the ``\ell_{2}`` norm operator composed with a function
+```math
+f(x) = λ \|c(x)\|_2
+```
+where ``\lambda > 0``. c! and J! should be functions
+```math
+\begin{aligned}
+&c(x) : \mathbb{R}^n \xrightarrow[]{} \mathbb{R}^m \\
+&J(x) : \mathbb{R}^n \xrightarrow[]{} \mathbb{R}^{m\times n}
+\end{aligned}
+```
+such that J is the Jacobian of c. A and b should respectively be a matrix and a vector which can respectively store the values of J and c.
+A is expected to be sparse, c and J should have signatures
+c!(b <: AbstractVector{Real}, xk <: AbstractVector{Real})
+J!(A <: AbstractSparseMatrix{Real,Integer}, xk <: AbstractVector{Real})
+"""
+mutable struct CompositeNormL2{
+    R <: Real,
+    V0 <: Function,
+    V1 <: Function,
+    V2 <: AbstractMatrix{R},
+    V3 <: AbstractVector{R},
+  } <: AbstractCompositeNorm
+    h::NormL2{R}
+    c!::V0
+    J!::V1
+    A::V2
+    b::V3
+
+    function CompositeNormL2(
+      λ::R,
+      c!::Function,
+      J!::Function,
+      A::AbstractMatrix{R},
+      b::AbstractVector{R},
+    ) where {R <: Real}
+      λ > 0 || error("CompositeNormL2: λ should be positive")
+      length(b) == size(A,1) || error("Composite Norm L2: Wrong input dimensions, c(x) should have same length as rows of J(x)")  
+      new{R, typeof(c!), typeof(J!), typeof(A), typeof(b)}(NormL2(λ), c!, J!, A, b)
+    end
+  end
+
+fun_name(f::CompositeNormL2) = "ℓ₂ norm of the function c"
+fun_dom(f::CompositeNormL2) = "AbstractVector{Real}"
+fun_expr(f::CompositeNormL2{T,V0,V1,V2,V3}) where {T <: Real,V0 <: Function, V1 <: Function, V2 <: AbstractMatrix{T}, V3 <: AbstractVector{T}} = "x ↦ λ ‖c(x)‖₂"

--- a/src/shiftedCompositeNormL2.jl
+++ b/src/shiftedCompositeNormL2.jl
@@ -1,0 +1,136 @@
+export ShiftedCompositeNormL2
+
+@doc raw"""
+    ShiftedCompositeNormL2(h, c!, J!, A, b)
+
+Returns the shift of a function c composed with the ``\ell_{2}`` norm (see CompositeNormL2.jl).
+Here, c is linearized i.e, ``c(x+s) \approx c(x) + J(x)s``. 
+```math
+f(s) = λ \|c(x) + J(x)s\|_2
+```
+where ``\lambda > 0``. c! and J! should be functions
+```math
+\begin{aligned}
+&c(x) : \mathbb{R}^n \xrightarrow[]{} \mathbb{R}^m \\
+&J(x) : \mathbb{R}^n \xrightarrow[]{} \mathbb{R}^{m\times n}
+\end{aligned}
+```
+such that J is the Jacobian of c. A and b should respectively be a matrix and a vector which can respectively store the values of J and c.
+"""
+mutable struct ShiftedCompositeNormL2{
+  R <: Real,
+  V0 <: Function,
+  V1 <: Function,
+  V2 <: AbstractMatrix{R},
+  V3 <: AbstractVector{R},
+} <: ShiftedCompositeProximableFunction
+  h::NormL2{R}
+  c!::V0
+  J!::V1
+  A::V2
+  b::V3
+  g::V3
+  res::V3
+  sol::V3
+  dsol::V3
+  function ShiftedCompositeNormL2(
+    λ::R,
+    c!::Function,
+    J!::Function,
+    A::AbstractMatrix{R},
+    b::AbstractVector{R},
+  ) where {R <: Real}
+    g = similar(b)
+    res = similar(b)
+    sol = similar(b)
+    dsol = similar(b)
+    if length(b) != size(A,1)
+      error("ShiftedCompositeNormL2: Wrong input dimensions, there should be as many constraints as rows in the Jacobian")
+    end
+    new{R,typeof(c!),typeof(J!),typeof(A),typeof(b)}(NormL2(λ),c!,J!,A,b,g,res,sol,dsol)
+  end
+end
+
+
+shifted(λ::R, c!::Function, J!::Function, A::AbstractMatrix{R}, b::AbstractVector{R}, xk :: AbstractVector{R}) where {R <: Real} = begin
+  c!(b,xk)
+  J!(A,xk)
+  ShiftedCompositeNormL2(λ,c!,J!,A,b)
+end
+
+shifted(
+  ψ::ShiftedCompositeNormL2{R, V0, V1, V2, V3},
+  xk::AbstractVector{R},
+) where {R <: Real, V0 <: Function, V1 <: Function, V2 <: AbstractMatrix{R}, V3<: AbstractVector{R}} = begin
+  b = similar(ψ.b)
+  ψ.c!(b,xk)
+  A = similar(ψ.A)
+  ψ.J!(A,xk)
+  ShiftedCompositeNormL2(ψ.h.lambda, ψ.c!, ψ.J!, A, b)
+end
+ 
+shifted(
+  ψ::CompositeNormL2{R, V0, V1, V2, V3},
+  xk::AbstractVector{R}
+) where {R <: Real, V0 <: Function, V1 <: Function, V2 <: AbstractMatrix{R}, V3 <: AbstractVector{R}} = begin
+  b = similar(ψ.b)
+  ψ.c!(b,xk)
+  A = similar(ψ.A)
+  ψ.J!(A,xk)
+  ShiftedCompositeNormL2(ψ.h.lambda, ψ.c!, ψ.J!, A, b)
+end
+
+fun_name(ψ::ShiftedCompositeNormL2) = "shifted L2 norm"
+fun_expr(ψ::ShiftedCompositeNormL2) = "t ↦ ‖c(xk) + J(xk)t‖₂"
+fun_params(ψ::ShiftedCompositeNormL2) = "c(xk) = $(ψ.b)\n" * " "^14 * "J(xk) = $(ψ.A)\n"
+
+function prox!(
+  y::AbstractVector{R},
+  ψ::ShiftedCompositeNormL2{R, V0, V1, V2, V3},
+  q::AbstractVector{R},
+  σ::R
+) where {R <: Real, V0 <: Function,V1 <:Function,V2 <: AbstractMatrix{R}, V3 <: AbstractVector{R}}
+
+  mul!(ψ.g, ψ.A, q)
+  ψ.g .+= ψ.b
+
+  #ψ.res .= ψ.g
+  spmat = qrm_spmat_init(ψ.A; sym=false)
+  spfct = qrm_spfct_init(spmat)
+  qrm_analyse!(spmat, spfct; transp='t')
+  qrm_set(spfct, "qrm_keeph", 0)
+  qrm_factorize!(spmat, spfct, transp='t')
+
+  qrm_solve!(spfct, ψ.g, y, transp='t')
+  qrm_solve!(spfct, y, ψ.sol, transp='n')
+
+  """
+  # 1 step of iterative refinement
+
+  mul!(y, ψ.A', ψ.sol)
+  mul!(ψ.dsol, ψ.A, y)
+
+  ψ.res .-= ψ.dsol
+
+  if norm(ψ.res) > eps(R)^0.75
+    qrm_solve!(spfct, ψ.res, y, transp='t')
+    qrm_solve!(spfct, y, ψ.dsol, transp='n')
+    ψ.sol .+= ψ.dsol
+  end  
+  """
+
+  ψ.sol .*= -1
+
+  # Scalar Root finding
+  α = 0.0
+  while norm(ψ.sol) >= σ*ψ.h.lambda
+
+    α += (norm(ψ.sol)/σ*ψ.h.lambda - 1.0)*(norm(y)/norm(ψ.sol))^2
+    ψ.sol .*= -1
+    
+  end
+
+  mul!(y, ψ.A', ψ.sol)
+  y .+= q
+  return y
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using LinearAlgebra
 using SparseArrays
+using SparseMatricesCOO
 using ProximalOperators
 using ShiftedProximalOperators
 using Test
@@ -16,14 +17,14 @@ for (op,composite_op,shifted_op) ∈ zip((:NormL2,), (:CompositeNormL2,), (:Shif
       z[2] = x[2] + x[3] 
     end
     function J!(z,x)
-      z .= sparse(Float64[2 0 0 -1;0 1 1 0])
+      z.vals .= Float64[2.0,1.0,1.0,-1.0]
     end
     λ = 3.62
     Op = eval(op)
     h = Op(λ)
 
     b = zeros(Float64,2)
-    A = sparse(Matrix{Float64}(undef,2,4))
+    A = SparseMatrixCOO(Float64[2 0 0 -1;0 1 1 0])
 
 
     ψ = CompositeOp(λ,c!,J!,A,b)
@@ -40,7 +41,7 @@ for (op,composite_op,shifted_op) ∈ zip((:NormL2,), (:CompositeNormL2,), (:Shif
     @test ϕ(zeros(Float64,4)) == h([0.4754,1.1741])
     @test ϕ(ones(Float64,4)) == h([0.4754,1.1741] + Float64[2 0 0 -1;0 1 1 0]*ones(Float64,4))
     @test ϕ.b == [0.4754,1.1741]
-    @test ϕ.A == sparse(Float64[2 0 0 -1;0 1 1 0])
+    @test ϕ.A == SparseMatrixCOO(Float64[2 0 0 -1;0 1 1 0])
 
     # test prox 
     x = [0.1097,1.1287,-0.29,1.2616]
@@ -50,7 +51,7 @@ for (op,composite_op,shifted_op) ∈ zip((:NormL2,), (:CompositeNormL2,), (:Shif
     
     if "$op" == "NormL2"
       y_true = [0.24545429,0.75250248,-0.66619752 ,1.19372286]
-      #@test sum((y - y_true) .^ 2) ≤ 1e-11
+      @test sum((y - y_true) .^ 2) ≤ 1e-11
     end
 
     # test in place shift
@@ -58,8 +59,8 @@ for (op,composite_op,shifted_op) ∈ zip((:NormL2,), (:CompositeNormL2,), (:Shif
     shift!(ϕ,xk)
     
     @test ϕ.b == [1.0,2.0]
-    @test ϕ.A == sparse(Float64[2 0 0 -1;0 1 1 0])
-    @test ϕ(ones(Float64,4)) == h([1.0,2.0] + sparse(Float64[2 0 0 -1;0 1 1 0])*ones(Float64,4))
+    @test ϕ.A == SparseMatrixCOO(Float64[2 0 0 -1;0 1 1 0])
+    @test ϕ(ones(Float64,4)) == h([1.0,2.0] + SparseMatrixCOO(Float64[2 0 0 -1;0 1 1 0])*ones(Float64,4))
 
     # test different types
     h = Op(Float32(λ))
@@ -68,10 +69,10 @@ for (op,composite_op,shifted_op) ∈ zip((:NormL2,), (:CompositeNormL2,), (:Shif
       z[2] = x[2] + x[3] 
     end
     function J!(z,x)
-      z .= sparse(Float32[2 0 0 -1;0 1 1 0])
+      z.vals .= Float32[2.0,1.0,1.0,-1.0]
     end
     b = zeros(Float32,2)
-    A = sparse(Matrix{Float32}(undef,2,4))
+    A = SparseMatrixCOO(Float32[2 0 0 -1;0 1 1 0])
 
     ψ = CompositeOp(Float32(λ),c!,J!,A,b)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,84 @@
 using LinearAlgebra
+using SparseArrays
 using ProximalOperators
 using ShiftedProximalOperators
 using Test
 
 include("test_psvd.jl")
+
+for (op,composite_op,shifted_op) ∈ zip((:NormL2,), (:CompositeNormL2,), (:ShiftedCompositeNormL2,))
+  @testset "$shifted_op" begin
+    ShiftedOp = eval(shifted_op)
+    CompositeOp = eval(composite_op)
+
+    function c!(z,x)
+      z[1] = 2*x[1] - x[4]
+      z[2] = x[2] + x[3] 
+    end
+    function J!(z,x)
+      z .= sparse(Float64[2 0 0 -1;0 1 1 0])
+    end
+    λ = 3.62
+    Op = eval(op)
+    h = Op(λ)
+
+    b = zeros(Float64,2)
+    A = sparse(Matrix{Float64}(undef,2,4))
+
+
+    ψ = CompositeOp(λ,c!,J!,A,b)
+
+    # test non shifted operator
+    @test ψ(ones(Float64,4)) == h([1,2])
+    @test all(ψ(zeros(Float64,4)) .== 0.0)
+    @test all(ψ.b .== 0.0)
+    
+    # test shifted operator
+    xk = [0.0,1.1741,0.0,-0.4754]
+    ϕ = shifted(ψ,xk)
+
+    @test ϕ(zeros(Float64,4)) == h([0.4754,1.1741])
+    @test ϕ(ones(Float64,4)) == h([0.4754,1.1741] + Float64[2 0 0 -1;0 1 1 0]*ones(Float64,4))
+    @test ϕ.b == [0.4754,1.1741]
+    @test ϕ.A == sparse(Float64[2 0 0 -1;0 1 1 0])
+
+    # test prox 
+    x = [0.1097,1.1287,-0.29,1.2616]
+    y = similar(x)
+    ν = 0.1056
+    prox!(y,ϕ,x,ν)
+    
+    if "$op" == "NormL2"
+      y_true = [0.24545429,0.75250248,-0.66619752 ,1.19372286]
+      #@test sum((y - y_true) .^ 2) ≤ 1e-11
+    end
+
+    # test in place shift
+    xk = ones(Float64,4)
+    shift!(ϕ,xk)
+    
+    @test ϕ.b == [1.0,2.0]
+    @test ϕ.A == sparse(Float64[2 0 0 -1;0 1 1 0])
+    @test ϕ(ones(Float64,4)) == h([1.0,2.0] + sparse(Float64[2 0 0 -1;0 1 1 0])*ones(Float64,4))
+
+    # test different types
+    h = Op(Float32(λ))
+    function c!(z,x)
+      z[1] = 2*x[1] - x[4]
+      z[2] = x[2] + x[3] 
+    end
+    function J!(z,x)
+      z .= sparse(Float32[2 0 0 -1;0 1 1 0])
+    end
+    b = zeros(Float32,2)
+    A = sparse(Matrix{Float32}(undef,2,4))
+
+    ψ = CompositeOp(Float32(λ),c!,J!,A,b)
+
+    @test typeof(ψ(zeros(Float32,4))) == Float32
+
+  end
+end
 
 #test Created norms/standard proxes - TODO: come up with more robust test
 for op ∈ (:RootNormLhalf,)


### PR DESCRIPTION
Implementation of the proximal operator of a composite term $||Ax+b||_2$. This is different from other operators of this library in the fact that shifts are no longer simply $\psi(x+s)$ for some non-differentiable function $\psi$. 
Hence, some abstract types are added in ShiftedProximalOperators.jl. 

In practice, such proximal operators are useful when we want to make a model of a penalty term $x \xrightarrow{} ||c(x)||_2$. The first-order model of the penalty term is then $s \xrightarrow{} ||c(x) + J(x)s||_2$.

As mentionned above, the shift is no longer simply $\psi(x+s)$. Hence, we add a CompositeNormL2 struct which mimics the unshifted function and implements $x\xrightarrow{} ||c(x)||_2$. On shifts, this transforms to a ShiftedCompositeNormL2 struct which implements $s\xrightarrow{} ||c(x)+J(x)s||_2$.

