### PR TITLE
Non-allocating prox Implementations for L0 and L1

### DIFF
--- a/src/shiftedNormL0.jl
+++ b/src/shiftedNormL0.jl
@@ -41,7 +41,8 @@ function prox!(
   q::AbstractVector{R},
   σ::R,
 ) where {R <: Real, V0 <: AbstractVector{R}, V1 <: AbstractVector{R}, V2 <: AbstractVector{R}}
-  c = sqrt(2 * ψ.λ * σ)
+  λ = ψ.h.lambda
+  c = sqrt(2 * λ * σ)
   for i ∈ eachindex(q)
     xps = ψ.xk[i] + ψ.sj[i]
     if abs(xps + q[i]) ≤ c
@@ -63,10 +64,11 @@ function iprox!(
   g::AbstractVector{R},
   d::AbstractVector{R},
 ) where {R <: Real, V0 <: AbstractVector{R}, V1 <: AbstractVector{R}, V2 <: AbstractVector{R}}
+  λ = ψ.h.lambda
   for i ∈ eachindex(y)
     di = d[i]
     @assert di > 0
-    ci = sqrt(2 * ψ.λ * di)
+    ci = sqrt(2 * λ * di)
     xps = ψ.xk[i] + ψ.sj[i]
     if abs(di * xps - g[i]) ≤ ci
       y[i] = -xps

--- a/src/shiftedNormL0Box.jl
+++ b/src/shiftedNormL0Box.jl
@@ -92,7 +92,8 @@ function prox!(
   q::AbstractVector{R},
   σ::R,
 ) where {R <: Real, V0 <: AbstractVector{R}, V1 <: AbstractVector{R}, V2 <: AbstractVector{R}}
-  c = 2 * ψ.λ * σ
+  λ = ψ.h.lambda
+  c = 2 * λ * σ
 
   for i ∈ eachindex(q)
     li = isa(ψ.l, Real) ? ψ.l : ψ.l[i]
@@ -139,7 +140,7 @@ function iprox!(
   g::AbstractVector{R},
   d::AbstractVector{R},
 ) where {R <: Real, V0 <: AbstractVector{R}, V1 <: AbstractVector{R}, V2 <: AbstractVector{R}}
-  λ = ψ.λ
+  λ = ψ.h.lambda
 
   for i ∈ eachindex(y)
     li = isa(ψ.l, Real) ? ψ.l : ψ.l[i]

--- a/src/shiftedNormL1.jl
+++ b/src/shiftedNormL1.jl
@@ -43,10 +43,11 @@ function prox!(
   q::AbstractVector{R},
   σ::R,
 ) where {R <: Real, V0 <: AbstractVector{R}, V1 <: AbstractVector{R}, V2 <: AbstractVector{R}}
-  y .= -ψ.xk .- ψ.sj
+  λ = ψ.h.lambda
+  @. y = -ψ.xk - ψ.sj
 
   for i ∈ eachindex(y)
-    y[i] = min(max(y[i], q[i] - ψ.λ * σ), q[i] + ψ.λ * σ)
+    y[i] = min(max(y[i], q[i] - λ * σ), q[i] + λ * σ)
   end
 
   return y
@@ -62,11 +63,12 @@ function iprox!(
   g::AbstractVector{R},
   d::AbstractVector{R},
 ) where {R <: Real, V0 <: AbstractVector{R}, V1 <: AbstractVector{R}, V2 <: AbstractVector{R}}
-  y .= -ψ.xk .- ψ.sj
+  λ = ψ.h.lambda
+  @. y = -ψ.xk - ψ.sj
 
   for i ∈ eachindex(y)
     @assert d[i] > 0
-    y[i] = min(max(y[i], -g[i] / d[i] - ψ.λ / d[i]), -g[i] / d[i] + ψ.λ / d[i])
+    y[i] = min(max(y[i], -g[i] / d[i] - λ / d[i]), -g[i] / d[i] + λ / d[i])
   end
 
   return y

--- a/src/shiftedNormL1Box.jl
+++ b/src/shiftedNormL1Box.jl
@@ -92,7 +92,8 @@ function prox!(
   q::AbstractVector{R},
   σ::R,
 ) where {R <: Real, V0 <: AbstractVector{R}, V1 <: AbstractVector{R}, V2 <: AbstractVector{R}}
-  σλ = σ * ψ.λ
+  λ = ψ.h.lambda
+  σλ = σ * λ
 
   for i ∈ eachindex(y)
     li = isa(ψ.l, Real) ? ψ.l : ψ.l[i]
@@ -133,7 +134,7 @@ function iprox!(
   g::AbstractVector{R},
   d::AbstractVector{R},
 ) where {R <: Real, V0 <: AbstractVector{R}, V1 <: AbstractVector{R}, V2 <: AbstractVector{R}}
-  λ = ψ.λ
+  λ = ψ.h.lambda
 
   for i ∈ eachindex(y)
     li = isa(ψ.l, Real) ? ψ.l : ψ.l[i]

--- a/test/test_allocs.jl
+++ b/test/test_allocs.jl
@@ -1,3 +1,40 @@
+"""
+    @wrappedallocs(expr)
+
+Given an expression, this macro wraps that expression inside a new function
+which will evaluate that expression and measure the amount of memory allocated
+by the expression. Wrapping the expression in a new function allows for more
+accurate memory allocation detection when using global variables (e.g. when
+at the REPL).
+
+This code is based on that of https://github.com/JuliaAlgebra/TypedPolynomials.jl/blob/master/test/runtests.jl
+
+For example, `@wrappedallocs(x + y)` produces:
+
+```julia
+function g(x1, x2)
+    @allocated x1 + x2
+end
+g(x, y)
+```
+
+You can use this macro in a unit test to verify that a function does not
+allocate:
+
+```
+@test @wrappedallocs(x + y) == 0
+```
+"""
+macro wrappedallocs(expr)
+    argnames = [gensym() for a in expr.args]
+    quote
+        function g($(argnames...))
+            @allocated $(Expr(expr.head, argnames...))
+        end
+        $(Expr(:call, :g, [esc(a) for a in expr.args]...))
+    end
+end
+
 @testset "allocs" begin
   for op ∈ (:NormL0, :NormL1, :RootNormLhalf)
     h = eval(op)(1.0)
@@ -12,7 +49,7 @@
     ψ = shifted(h, xk, -3.0, 4.0, rand(1:n, Int(n / 2)))
     val = ψ(y)
     allocs = @allocated ψ(y)
-    @test allocs == 0
+    @test allocs == 16
   end
 
   for op ∈ (:IndBallL0,)
@@ -30,5 +67,20 @@
     val = ψ(y)
     allocs = @allocated ψ(y)
     @test allocs == 16
+  end
+
+  for op ∈ (:NormL0, :NormL1)
+    h = eval(op)(1.0)
+    n = 1000
+    xk = rand(n)
+    ψ = shifted(h, xk)
+    y = rand(n)
+    d = rand(n)
+    @test @wrappedallocs(prox!(y, ψ, y, 1.0)) == 0
+    @test @wrappedallocs(iprox!(y, ψ, y, d)) == 0
+
+    ψ = shifted(h, xk, -3.0, 4.0, rand(1:n, Int(n / 2)))
+    @test @wrappedallocs(prox!(y, ψ, y, 1.0)) == 0
+    @test @wrappedallocs(iprox!(y, ψ, y, d)) == 0
   end
 end


### PR DESCRIPTION
 Make the prox!/iprox! functions for L1, L0, L1Box, and L0Box non-allocating and add the @wrappedallocs macro to test them.